### PR TITLE
Adding zip facility for zippered iteration

### DIFF
--- a/.github/workflows/linux_debug.yml
+++ b/.github/workflows/linux_debug.yml
@@ -1,0 +1,61 @@
+# Copyright (c) 2023 Hartmut Kaiser
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+name: Linux CI (Release)
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: stellargroup/build_env:latest
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+          repository: ct-clmsn/chplx.git
+          fetch-depth: 1
+    - name: Install dependencies
+      shell: bash
+      run: |
+          mkdir -p /tmp/hpx
+          cd /tmp/hpx
+          git clone \
+              --branch master \
+              --single-branch \
+              --depth 1 \
+              https://github.com/STEllAR-GROUP/hpx.git
+          mkdir -p build
+          cd build
+          cmake \
+              ../hpx \
+              -GNinja \
+              -DCMAKE_BUILD_TYPE=Debug \
+              -DHPX_WITH_UNITY_BUILD=ON \
+              -DHPX_WITH_MALLOC=system \
+              -DHPX_WITH_EXAMPLES=OFF \
+              -DHPX_WITH_TESTS=OFF
+          ninja install
+    - name: Configure
+      shell: bash
+      run: |
+          cmake \
+              ./library \
+              -GNinja \
+              -DCMAKE_BUILD_TYPE=Debug
+    - name: Build
+      shell: bash
+      run: |
+          cmake --build build --target all
+    - name: Test
+      shell: bash
+      run: |
+          cd build
+          ctest --output-on-failure

--- a/.github/workflows/linux_release.yml
+++ b/.github/workflows/linux_release.yml
@@ -1,0 +1,61 @@
+# Copyright (c) 2023 Hartmut Kaiser
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+name: Linux CI (Release)
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: stellargroup/build_env:latest
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+          repository: ct-clmsn/chplx.git
+          fetch-depth: 1
+    - name: Install dependencies
+      shell: bash
+      run: |
+          mkdir -p /tmp/hpx
+          cd /tmp/hpx
+          git clone \
+              --branch master \
+              --single-branch \
+              --depth 1 \
+              https://github.com/STEllAR-GROUP/hpx.git
+          mkdir -p build
+          cd build
+          cmake \
+              ../hpx \
+              -GNinja \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DHPX_WITH_UNITY_BUILD=ON \
+              -DHPX_WITH_MALLOC=system \
+              -DHPX_WITH_EXAMPLES=OFF \
+              -DHPX_WITH_TESTS=OFF
+          ninja install
+    - name: Configure
+      shell: bash
+      run: |
+          cmake \
+              ./library \
+              -GNinja \
+              -DCMAKE_BUILD_TYPE=Release
+    - name: Build
+      shell: bash
+      run: |
+          cmake --build build --target all
+    - name: Test
+      shell: bash
+      run: |
+          cd build
+          ctest --output-on-failure

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -55,7 +55,8 @@ set(chplx_library_headers
     include/chplx/range.hpp
     include/chplx/tuple.hpp
     include/chplx/types.hpp
-    include/chplx/version.hpp)
+    include/chplx/version.hpp
+    include/chplx/zip.hpp)
 source_group("Header Files/chplx" FILES
     ${chplx_library_headers})
 

--- a/library/include/chplx.hpp
+++ b/library/include/chplx.hpp
@@ -19,3 +19,4 @@
 #include <chplx/tuple.hpp>
 #include <chplx/types.hpp>
 #include <chplx/version.hpp>
+#include <chplx/zip.hpp>

--- a/library/include/chplx/adapt_domain.hpp
+++ b/library/include/chplx/adapt_domain.hpp
@@ -52,29 +52,4 @@ decltype(auto) iterate(Domain<N, T, Stridable> const &d) noexcept {
   return iterate(detail::IteratorGenerator(d));
 }
 
-//-----------------------------------------------------------------------------
-template <int N, typename T, bool Stridable>
-constexpr bool
-empty(detail::IteratorGenerator<Domain<N, T, Stridable>> const &d) noexcept {
-
-  return d.size == 0;
-}
-
-template <int N, typename T, bool Stridable>
-constexpr auto
-size(detail::IteratorGenerator<Domain<N, T, Stridable>> const &d) noexcept {
-
-  return d.size;
-}
-
-template <int N, typename T, bool Stridable>
-auto subrange(detail::IteratorGenerator<Domain<N, T, Stridable>> const &d,
-              std::ptrdiff_t first, std::size_t size) {
-
-  auto result = detail::IteratorGenerator<Domain<N, T, Stridable>>(
-      d.target, d.first + first, size);
-
-  return result;
-}
-
 } // namespace chplx

--- a/library/include/chplx/adapt_range.hpp
+++ b/library/include/chplx/adapt_range.hpp
@@ -38,32 +38,4 @@ decltype(auto) iterate(Range<T, BoundedType, Stridable> const &r) noexcept {
   return iterate(detail::IteratorGenerator(r));
 }
 
-//-----------------------------------------------------------------------------
-template <typename T, BoundedRangeType BoundedType, bool Stridable>
-constexpr auto
-size(detail::IteratorGenerator<Range<T, BoundedType, Stridable>> const
-         &r) noexcept {
-
-  return r.size;
-}
-
-template <typename T, BoundedRangeType BoundedType, bool Stridable>
-constexpr bool
-empty(detail::IteratorGenerator<Range<T, BoundedType, Stridable>> const
-          &r) noexcept {
-
-  return r.size == 0;
-}
-
-template <typename T, BoundedRangeType BoundedType, bool Stridable>
-auto subrange(
-    detail::IteratorGenerator<Range<T, BoundedType, Stridable>> const &r,
-    std::ptrdiff_t first, std::size_t size) {
-
-  auto result = detail::IteratorGenerator<Range<T, BoundedType, Stridable>>(
-      r.target, r.first + first, size);
-
-  return result;
-}
-
 } // namespace chplx

--- a/library/include/chplx/coforall_loop.hpp
+++ b/library/include/chplx/coforall_loop.hpp
@@ -11,6 +11,7 @@
 #include <chplx/detail/iterator_generator.hpp>
 #include <chplx/range.hpp>
 #include <chplx/tuple.hpp>
+#include <chplx/zip.hpp>
 
 #include <hpx/algorithm.hpp>
 #include <hpx/execution.hpp>
@@ -20,7 +21,7 @@ namespace chplx {
 //-----------------------------------------------------------------------------
 // coforall loop for tuples
 template <typename... Ts, typename F>
-void coforallLoop(Tuple<Ts...> const &t, F &&f) {
+void coforallLoop(Tuple<Ts...> &t, F &&f) {
 
   if constexpr (sizeof...(Ts) != 0) {
 
@@ -72,6 +73,20 @@ void coforallLoop(Domain<N, T, Stridable> const &d, F &&f) {
 
   hpx::ranges::experimental::for_loop(
       policy.with(scs), detail::IteratorGenerator(d), std::forward<F>(f));
+}
+
+//-----------------------------------------------------------------------------
+// forall loop for zippered iteration
+template <typename... Rs, typename F>
+void coforallLoop(detail::ZipRange<Rs...> const &zr, F &&f) {
+
+  hpx::execution::experimental::static_chunk_size scs(1);
+  auto policy = hpx::parallel::util::adapt_sharing_mode(
+      hpx::execution::par,
+      hpx::threads::thread_sharing_hint::do_not_combine_tasks);
+
+  hpx::ranges::experimental::for_loop(
+      policy.with(scs), detail::IteratorGenerator(zr), std::forward<F>(f));
 }
 
 } // namespace chplx

--- a/library/include/chplx/detail/iterator_generator.hpp
+++ b/library/include/chplx/detail/iterator_generator.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <chplx/types.hpp>
+
 #include <cstddef>
 #include <type_traits>
 #include <utility>
@@ -16,11 +18,14 @@ template <typename Target> struct IteratorGenerator {
 
   template <typename T>
     requires(!std::is_same_v<std::decay_t<T>, IteratorGenerator>)
-  IteratorGenerator(T &&target)
-      : target(std::forward<T>(target)), first(0), size(target.size()) {}
+  explicit constexpr IteratorGenerator(T &&target)
+      : target(std::forward<T>(target)), first(0),
+        size(target.isBounded()
+                 ? target.size()
+                 : MaxValue_v<typename std::decay_t<T>::idxType>) {}
 
   template <typename T>
-  IteratorGenerator(T &&target, std::size_t first, std::size_t size)
+  constexpr IteratorGenerator(T &&target, std::size_t first, std::size_t size)
       : target(std::forward<T>(target)), first(first), size(size) {}
 
   constexpr bool operator==(IteratorGenerator const &rhs) noexcept {
@@ -34,4 +39,31 @@ template <typename Target> struct IteratorGenerator {
 
 template <typename Target>
 IteratorGenerator(Target &&target) -> IteratorGenerator<std::decay_t<Target>>;
+
+template <typename Target>
+IteratorGenerator(Target &&target, std::size_t, std::size_t)
+    -> IteratorGenerator<std::decay_t<Target>>;
+
+//-----------------------------------------------------------------------------
+template <typename R>
+constexpr auto size(IteratorGenerator<R> const &r) noexcept {
+
+  return r.size;
+}
+
+template <typename R>
+constexpr bool empty(IteratorGenerator<R> const &r) noexcept {
+
+  return r.size == 0;
+}
+
+template <typename R>
+auto subrange(IteratorGenerator<R> const &r, std::ptrdiff_t first,
+              std::size_t size) {
+
+  auto result = IteratorGenerator(r.target, r.first + first, size);
+
+  return result;
+}
+
 } // namespace chplx::detail

--- a/library/include/chplx/domain.hpp
+++ b/library/include/chplx/domain.hpp
@@ -146,22 +146,28 @@ public:
       std::conditional_t<std::is_enum_v<idxType>, std::int64_t, idxType>;
 
   // Return true if this is a stridable domain
-  static constexpr bool stridable() noexcept { return Stridable; }
+  [[nodiscard]] static constexpr bool stridable() noexcept { return Stridable; }
 
   // Return the number of indices in this domain as an int.
-  constexpr std::int64_t size() const noexcept {
+  [[nodiscard]] constexpr std::int64_t size() const noexcept {
     return reduce(shape(), std::multiplies<>(), 1);
   }
 
   // Return the number of indices in this domain as the specified type
   template <typename T>
     requires(std::is_integral_v<T>)
-  constexpr T sizeAs() const noexcept {
+  [[nodiscard]] constexpr T sizeAs() const noexcept {
     return reduce(shape(), std::multiplies<>(), static_cast<T>(1));
   }
 
+  // Returns true if this is a fully bounded domain, false otherwise.
+  [[nodiscard]] constexpr bool isBounded() const noexcept {
+    return reduce(detail::lift(indices, [](auto &&r) { return r.isBounded(); }),
+                  std::logical_and<>(), true);
+  }
+
   // Yield the domain indices
-  decltype(auto) these() const { return iterate(*this); }
+  [[nodiscard]] decltype(auto) these() const { return iterate(*this); }
 
   // Return a tuple of ranges describing the bounds of a rectangular domain. For
   // a sparse domain, return the bounds of the parent domain.
@@ -170,94 +176,99 @@ public:
 
   // Return a range representing the boundary of this domain in a particular
   // dimension.
-  constexpr auto dim(int i) const noexcept { return indices[i]; }
+  [[nodiscard]] constexpr auto dim(int i) const noexcept { return indices[i]; }
 
   // Return a tuple of int values representing the size of each dimension.
-  constexpr decltype(auto) shape() const noexcept {
+  [[nodiscard]] constexpr decltype(auto) shape() const noexcept {
     return detail::lift(indices, [](auto &&r) { return r.size(); });
   }
 
   // Returns the domain's 'pure' low bound.
-  constexpr decltype(auto) lowBound() const noexcept {
+  [[nodiscard]] constexpr decltype(auto) lowBound() const noexcept {
     return detail::lift(indices, [](auto &&r) { return r.lowBound(); });
   }
 
   // Return the lowest index represented by a rectangular domain.
-  constexpr decltype(auto) low() const noexcept {
+  [[nodiscard]] constexpr decltype(auto) low() const noexcept {
     return detail::lift(indices, [](auto &&r) { return r.low(); });
   }
 
   // Return the first index in this domain.
-  constexpr decltype(auto) first() const noexcept {
+  [[nodiscard]] constexpr decltype(auto) first() const noexcept {
     return detail::lift(indices, [](auto &&r) { return r.first(); });
   }
 
   // Returns the domain's 'pure' high bound.
-  constexpr decltype(auto) highBound() const noexcept {
+  [[nodiscard]] constexpr decltype(auto) highBound() const noexcept {
     return detail::lift(indices, [](auto &&r) { return r.highBound(); });
   }
 
   // Return the highest index represented by a rectangular domain.
-  constexpr decltype(auto) high() const noexcept {
+  [[nodiscard]] constexpr decltype(auto) high() const noexcept {
     return detail::lift(indices, [](auto &&r) { return r.high(); });
   }
 
   // Return the last index in this domain.
-  constexpr decltype(auto) last() const noexcept {
+  [[nodiscard]] constexpr decltype(auto) last() const noexcept {
     return detail::lift(indices, [](auto &&r) { return r.last(); });
   }
 
   // Return the stride of the indices in this domain.
-  constexpr decltype(auto) stride() const noexcept {
+  [[nodiscard]] constexpr decltype(auto) stride() const noexcept {
     return detail::lift(indices, [](auto &&r) { return r.stride(); });
   }
 
   // Return the alignment of the indices in this domain
-  constexpr decltype(auto) alignment() const noexcept {
+  [[nodiscard]] constexpr decltype(auto) alignment() const noexcept {
     return detail::lift(indices, [](auto &&r) { return r.alignment(); });
   }
 
   // Return the alignment of the indices in this domain
-  constexpr decltype(auto) contains(indexType const &idx) const noexcept {
+  [[nodiscard]] constexpr decltype(auto)
+  contains(indexType const &idx) const noexcept {
     return detail::lift(indices, idx,
                         [](auto &&r, idxType i) { return r.contains(i); });
   }
 
   // Return the alignment of the indices in this domain
   template <typename IndexType1, bool Stridable1>
-  constexpr decltype(auto)
+  [[nodiscard]] constexpr decltype(auto)
   contains(Domain<N, IndexType1, Stridable1> const &other) const noexcept {
     return detail::lift(indices, other.dims(),
                         [](auto &&r1, auto &&r2) { return r1.contains(r2); });
   }
 
   // Return true if this domain is a rectangular. Otherwise return false.
-  static constexpr bool isRectangular() noexcept { return true; }
+  [[nodiscard]] static constexpr bool isRectangular() noexcept { return true; }
 
   // Return true if d is an irregular domain; e.g. is not rectangular. Otherwise
   // return false.
-  static constexpr bool isIrregular() noexcept { return !isRectangular(); }
+  [[nodiscard]] static constexpr bool isIrregular() noexcept {
+    return !isRectangular();
+  }
 
   // Return true if d is an associative domain. Otherwise return false.
-  static constexpr bool isAssociative() noexcept { return false; }
+  [[nodiscard]] static constexpr bool isAssociative() noexcept { return false; }
 
   // Return true if d is a sparse domain. Otherwise return false.
-  static constexpr bool isSparse() noexcept { return false; }
+  [[nodiscard]] static constexpr bool isSparse() noexcept { return false; }
 
-  static constexpr int rank() noexcept { return N; }
+  [[nodiscard]] static constexpr int rank() noexcept { return N; }
 
   // Returns an integer representing the zero-based ordinal value of ind within
   // the domain's sequence of values if it is a member of the sequence.
   // Otherwise, returns -1. The indexOrder procedure is the reverse of
   // orderToIndex.
-  constexpr std::int64_t indexOrder(indexType idx) const noexcept {
+  [[nodiscard]] constexpr std::int64_t
+  indexOrder(indexType idx) const noexcept {
 
     return detail::IndexOrder<N - 1>::call(*this, idx);
   }
 
   // Returns the zero-based ord-th element of this domain's represented
   // sequence. The orderToIndex procedure is the reverse of indexOrder.
-  constexpr indexType orderToIndex(std::int64_t order) const noexcept {
+  [[nodiscard]] constexpr indexType
+  orderToIndex(std::int64_t order) const noexcept {
 
     return detail::OrderToIndex<N - 1>::template call<N - 1>(*this, order);
   }

--- a/library/include/chplx/for_loop.hpp
+++ b/library/include/chplx/for_loop.hpp
@@ -12,6 +12,7 @@
 #include <chplx/domain.hpp>
 #include <chplx/range.hpp>
 #include <chplx/tuple.hpp>
+#include <chplx/zip.hpp>
 
 namespace chplx {
 
@@ -20,15 +21,15 @@ namespace detail {
 
 // 'iterate'  over non-homogenous tuple
 template <typename... Ts, typename F, std::size_t... Is>
-void forLoop(Tuple<Ts...> const &t, F &&f, std::index_sequence<Is...>) {
+void forLoop(Tuple<Ts...> &t, F &&f, std::index_sequence<Is...>) {
 
   (f(std::get<Is>(t)), ...);
 }
+
 } // namespace detail
 
 // for loop for tuples
-template <typename... Ts, typename F>
-void forLoop(Tuple<Ts...> const &t, F &&f) {
+template <typename... Ts, typename F> void forLoop(Tuple<Ts...> &t, F &&f) {
 
   if constexpr (sizeof...(Ts) != 0) {
 
@@ -37,11 +38,11 @@ void forLoop(Tuple<Ts...> const &t, F &&f) {
       for (auto const &e : HomogenousTupleRange(t.base())) {
         f(e);
       }
-    }
-  } else {
+    } else {
 
-    detail::forLoop(t, std::forward<F>(f),
-                    std::make_index_sequence<sizeof...(Ts)>{});
+      detail::forLoop(t, std::forward<F>(f),
+                      std::make_index_sequence<sizeof...(Ts)>{});
+    }
   }
 }
 
@@ -61,6 +62,16 @@ template <int N, typename T, bool Stridable, typename F>
 void forLoop(Domain<N, T, Stridable> const &d, F &&f) {
 
   for (auto const &e : d.these()) {
+    f(e);
+  }
+}
+
+//-----------------------------------------------------------------------------
+// for loop for zippered iteration
+template <typename... Rs, typename F>
+void forLoop(detail::ZipRange<Rs...> const &zr, F &&f) {
+
+  for (auto const &e : zr.these()) {
     f(e);
   }
 }

--- a/library/include/chplx/forall_loop.hpp
+++ b/library/include/chplx/forall_loop.hpp
@@ -12,6 +12,7 @@
 #include <chplx/detail/iterator_generator.hpp>
 #include <chplx/range.hpp>
 #include <chplx/tuple.hpp>
+#include <chplx/zip.hpp>
 
 #include <hpx/algorithm.hpp>
 #include <hpx/execution.hpp>
@@ -20,8 +21,7 @@ namespace chplx {
 
 //-----------------------------------------------------------------------------
 // forall loop for tuples
-template <typename... Ts, typename F>
-void forallLoop(Tuple<Ts...> const &t, F &&f) {
+template <typename... Ts, typename F> void forallLoop(Tuple<Ts...> &t, F &&f) {
 
   if constexpr (sizeof...(Ts) != 0) {
 
@@ -58,6 +58,15 @@ void forallLoop(Domain<N, T, Stridable> const &d, F &&f) {
 
   hpx::ranges::experimental::for_loop(
       hpx::execution::par, detail::IteratorGenerator(d), std::forward<F>(f));
+}
+
+//-----------------------------------------------------------------------------
+// forall loop for zippered iteration
+template <typename... Rs, typename F>
+void forallLoop(detail::ZipRange<Rs...> const &zr, F &&f) {
+
+  hpx::ranges::experimental::for_loop(
+      hpx::execution::par, detail::IteratorGenerator(zr), std::forward<F>(f));
 }
 
 } // namespace chplx

--- a/library/include/chplx/types.hpp
+++ b/library/include/chplx/types.hpp
@@ -10,6 +10,7 @@
 
 #include <complex>
 #include <cstdint>
+#include <limits>
 #include <string>
 #include <type_traits>
 
@@ -183,4 +184,39 @@ template <typename T> [[nodiscard]] constexpr bool isEnumValue(T) noexcept {
   return std::is_enum_v<T>;
 }
 
+namespace detail {
+
+//-----------------------------------------------------------------------------
+template <typename T, typename Enable = std::enable_if_t<!std::is_enum_v<T>>>
+struct MinValue {
+  static constexpr T value = (std::numeric_limits<T>::min)();
+};
+
+template <typename T> struct MinValue<T, std::enable_if_t<std::is_enum_v<T>>> {
+  static constexpr T value = T::minValue;
+};
+
+template <> struct MinValue<bool> {
+  static constexpr bool value = false;
+};
+
+template <typename T> inline constexpr auto MinValue_v = MinValue<T>::value;
+
+//-----------------------------------------------------------------------------
+template <typename T, typename Enable = std::enable_if_t<!std::is_enum_v<T>>>
+struct MaxValue {
+  static constexpr T value = (std::numeric_limits<T>::max)();
+};
+
+template <typename T> struct MaxValue<T, std::enable_if_t<std::is_enum_v<T>>> {
+  static constexpr T value = T::maxValue;
+};
+
+template <> struct MaxValue<bool> {
+  static constexpr bool value = true;
+};
+
+template <typename T> inline constexpr auto MaxValue_v = MaxValue<T>::value;
+
+} // namespace detail
 } // namespace chplx

--- a/library/include/chplx/zip.hpp
+++ b/library/include/chplx/zip.hpp
@@ -1,0 +1,209 @@
+//  Copyright (c) 2023 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <chplx/tuple.hpp>
+#include <chplx/types.hpp>
+
+#include <hpx/generator.hpp>
+#include <hpx/modules/datastructures.hpp>
+#include <hpx/modules/iterator_support.hpp>
+#include <hpx/modules/type_support.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <iterator>
+#include <type_traits>
+#include <utility>
+
+namespace hpx::util {
+
+namespace detail {
+
+template <typename... Ts, std::size_t... Is>
+constexpr hpx::tuple<Ts...> toHpxTuple(chplx::Tuple<Ts...> &&t,
+                                       std::index_sequence<Is...>) noexcept {
+
+  return hpx::tuple<Ts...>(std::get<Is>(std::move(t))...);
+}
+
+template <typename... Ts>
+constexpr hpx::tuple<Ts...> toHpxTuple(chplx::Tuple<Ts...> &&t) noexcept {
+
+  return toHpxTuple(std::move(t), std::make_index_sequence<sizeof...(Ts)>());
+}
+
+template <typename... Ts, std::size_t... Is>
+constexpr chplx::Tuple<Ts...> toTuple(hpx::tuple<Ts...> &&t,
+                                      std::index_sequence<Is...>) noexcept {
+
+  return chplx::Tuple<Ts...>(hpx::get<Is>(std::move(t))...);
+}
+
+template <typename... Ts>
+constexpr chplx::Tuple<Ts...> toTuple(hpx::tuple<Ts...> &&t) noexcept {
+
+  return toTuple(std::move(t), std::make_index_sequence<sizeof...(Ts)>());
+}
+
+template <typename... Ts>
+using ToTuple_t = decltype(toTuple(std::declval<hpx::tuple<Ts...>>()));
+
+} // namespace detail
+
+//-----------------------------------------------------------------------------
+// Add a zip_iterator specialization that is initialized from a chplx::Tuple
+template <typename... Ts>
+class zip_iterator<chplx::Tuple<Ts...>>
+    : public hpx::util::detail::zip_iterator_base<
+          hpx::tuple<Ts...>, zip_iterator<chplx::Tuple<Ts...>>> {
+
+  static_assert(sizeof...(Ts) != 0,
+                "zip_iterator must wrap at least one iterator");
+
+  using base_type =
+      hpx::util::detail::zip_iterator_base<hpx::tuple<Ts...>,
+                                           zip_iterator<chplx::Tuple<Ts...>>>;
+
+  friend class hpx::util::iterator_core_access;
+
+  // special dereference to return a chplx::Tuple
+  constexpr decltype(auto) dereference() const {
+
+    return detail::toTuple(base_type::dereference());
+  }
+
+public:
+  using reference = detail::ToTuple_t<typename base_type::reference>;
+
+  constexpr zip_iterator() noexcept : base_type() {}
+
+  explicit constexpr zip_iterator(Ts const &...ts) noexcept
+      : base_type(hpx::tie(ts...)) {}
+
+  explicit constexpr zip_iterator(chplx::Tuple<Ts...> &&t) noexcept
+      : base_type(detail::toHpxTuple(std::move(t))) {}
+
+  constexpr zip_iterator(zip_iterator const &other) = default;
+  constexpr zip_iterator(zip_iterator &&other) noexcept = default;
+
+  zip_iterator &operator=(zip_iterator const &other) = default;
+  zip_iterator &operator=(zip_iterator &&other) noexcept = default;
+
+  template <typename... Ts_>
+    requires(std::is_assignable_v<
+             typename zip_iterator::iterator_tuple_type &,
+             typename zip_iterator<Ts_...>::iterator_tuple_type &&>)
+  zip_iterator &operator=(zip_iterator<Ts_...> const &other) {
+    base_type::operator=(base_type(other.get_iterator_tuple()));
+    return *this;
+  }
+
+  template <typename... Ts_>
+    requires(std::is_assignable_v<
+             typename zip_iterator::iterator_tuple_type &,
+             typename zip_iterator<Ts_...>::iterator_tuple_type &&>)
+  zip_iterator &operator=(zip_iterator<Ts_...> &&other) noexcept {
+    base_type::operator=(base_type(HPX_MOVE(other).get_iterator_tuple()));
+    return *this;
+  }
+};
+
+template <typename... Ts>
+zip_iterator(chplx::Tuple<Ts...> &&) -> zip_iterator<chplx::Tuple<Ts...>>;
+
+} // namespace hpx::util
+
+namespace chplx {
+
+namespace detail {
+
+//-----------------------------------------------------------------------------
+template <typename... Rs> struct ZipRange : Tuple<Rs...> {
+
+  using base_type = Tuple<Rs...>;
+
+  using idxType = std::common_type_t<typename std::decay_t<Rs>::indexType...>;
+  using indexType = Tuple<typename std::decay_t<Rs>::indexType...>;
+
+  base_type &base() { return static_cast<base_type &>(*this); }
+  base_type const &base() const {
+    return static_cast<base_type const &>(*this);
+  }
+
+  template <typename... Rs_>
+    requires(sizeof...(Rs) == sizeof...(Rs_))
+  constexpr ZipRange(Rs_ &&...rs) : base_type(std::forward<Rs_>(rs)...) {}
+
+  // The zip operation is iterable only if all zippered objects are iterable
+  [[nodiscard]] constexpr bool isIterable() const noexcept {
+    return reduce(lift(base(), [](auto &&r) { return r.isIterable(); }),
+                  std::logical_and<>(), true);
+  }
+
+  // The zip operation is bounded if at least one of the zippered objects is
+  // bounded.
+  [[nodiscard]] constexpr bool isBounded() const noexcept {
+    return reduce(lift(base(), [](auto &&r) { return r.isBounded(); }),
+                  std::logical_or<>(), false);
+  }
+
+  // Compute the size of the zippered object. It is the size of the shortest
+  // iteration sequence exposed by all of the zippered objects.
+  [[nodiscard]] constexpr std::size_t size() const noexcept {
+    return reduce(
+        lift(base(),
+             [](auto &&r) {
+               return r.isBounded() ? r.size() : MaxValue_v<std::size_t>;
+             }),
+        [](std::size_t init, std::size_t val) { return (std::min)(init, val); },
+        MaxValue_v<std::size_t>);
+  }
+
+  // Return a Tuple of all index values corresponding to the given sequence
+  // order.
+  [[nodiscard]] constexpr indexType
+  orderToIndex(std::size_t order) const noexcept {
+    return lift(base(), [order](auto &&r) { return r.orderToIndex(order); });
+  }
+
+  // Yield the zipped indices
+  [[nodiscard]] decltype(auto) these() const { return iterate(*this); }
+};
+
+template <typename... Rs>
+hpx::generator<typename ZipRange<Rs...>::indexType>
+iterate(IteratorGenerator<ZipRange<Rs...>> zr) noexcept {
+
+  HPX_ASSERT(zr.target.isIterable());
+
+  auto size = zr.size;
+  for (auto ilo = zr.first; size-- != 0; ++ilo) {
+    co_yield zr.target.orderToIndex(ilo);
+  }
+}
+
+//-----------------------------------------------------------------------------
+template <typename... Rs>
+decltype(auto) iterate(ZipRange<Rs...> const &zr) noexcept {
+
+  return iterate(detail::IteratorGenerator(zr));
+}
+
+} // namespace detail
+
+//-----------------------------------------------------------------------------
+template <typename R, typename... Rs>
+constexpr detail::ZipRange<R, Rs...> zip(R &&r, Rs &&...rs) {
+
+  HPX_ASSERT_MSG(r.isIterable() && (rs.isIterable() && ...),
+                 "all zippered objects need to be iterable");
+
+  return detail::ZipRange<R, Rs...>(std::forward<R>(r),
+                                    std::forward<Rs>(rs)...);
+}
+} // namespace chplx

--- a/library/test/support/CMakeLists.txt
+++ b/library/test/support/CMakeLists.txt
@@ -8,16 +8,20 @@ set(tests test_index_generator
     test_coforall_loop_domain
     test_coforall_loop_range
     test_coforall_loop_tuple
+    test_coforall_loop_zip
     test_forall_loop_domain
     test_forall_loop_range
     test_forall_loop_tuple
+    test_forall_loop_zip
     test_for_loop_domain
     test_for_loop_range
     test_for_loop_tuple
+    test_for_loop_zip
     test_print_range
     test_domain
     test_range
     test_tuple
+    test_zip
 )
 
 foreach(test ${tests})

--- a/library/test/support/test_coforall_loop_domain.cpp
+++ b/library/test/support/test_coforall_loop_domain.cpp
@@ -10,6 +10,7 @@
 #include <hpx/modules/testing.hpp>
 #include <hpx/thread.hpp>
 
+#include <cstddef>
 #include <mutex>
 #include <set>
 
@@ -20,7 +21,7 @@ void testCoforallLoopDomain(chplx::Domain<N, T, Stridable> d) {
   std::set<indexType> values;
   hpx::mutex mtx;
 
-  T count = 0;
+  std::size_t count = 0;
 
   chplx::coforallLoop(d, [&](auto value) {
     std::lock_guard l(mtx);
@@ -29,7 +30,7 @@ void testCoforallLoopDomain(chplx::Domain<N, T, Stridable> d) {
     HPX_TEST(p.second);
   });
 
-  HPX_TEST_EQ(count, d.size());
+  HPX_TEST_EQ(count, static_cast<std::size_t>(d.size()));
   count = 0;
 
   for (auto val : d.these()) {
@@ -37,7 +38,7 @@ void testCoforallLoopDomain(chplx::Domain<N, T, Stridable> d) {
     HPX_TEST(values.contains(val));
   }
 
-  HPX_TEST_EQ(count, d.size());
+  HPX_TEST_EQ(count, values.size());
 }
 
 namespace detail {

--- a/library/test/support/test_coforall_loop_range.cpp
+++ b/library/test/support/test_coforall_loop_range.cpp
@@ -10,13 +10,14 @@
 #include <hpx/modules/testing.hpp>
 #include <hpx/thread.hpp>
 
+#include <cstddef>
 #include <mutex>
 #include <set>
 
 template <typename T, chplx::BoundedRangeType BoundedType, bool Stridable>
 void testCoforallLoopRange(chplx::Range<T, BoundedType, Stridable> r) {
 
-  T count = 0;
+  std::size_t count = 0;
 
   std::set<T> values;
   hpx::mutex mtx;
@@ -28,7 +29,7 @@ void testCoforallLoopRange(chplx::Range<T, BoundedType, Stridable> r) {
     HPX_TEST(p.second);
   });
 
-  HPX_TEST_EQ(count, r.size());
+  HPX_TEST_EQ(count, static_cast<std::size_t>(r.size()));
   count = 0;
 
   for (auto val : r.these()) {
@@ -36,7 +37,7 @@ void testCoforallLoopRange(chplx::Range<T, BoundedType, Stridable> r) {
     HPX_TEST(values.contains(val));
   }
 
-  HPX_TEST_EQ(count, r.size());
+  HPX_TEST_EQ(count, values.size());
 }
 
 int main() {

--- a/library/test/support/test_coforall_loop_zip.cpp
+++ b/library/test/support/test_coforall_loop_zip.cpp
@@ -1,0 +1,73 @@
+//  Copyright (c) 2023 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <chplx.hpp>
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/modules/testing.hpp>
+#include <hpx/thread.hpp>
+
+#include <cstddef>
+#include <mutex>
+#include <set>
+
+template <typename... Rs> void testCoforallLoopZip(Rs &&...rs) {
+
+  std::size_t count = 0;
+
+  auto zip = chplx::zip(std::forward<Rs>(rs)...);
+  std::set<typename decltype(zip)::indexType> values;
+
+  hpx::mutex mtx;
+
+  chplx::coforallLoop(zip, [&](auto value) {
+    std::lock_guard l(mtx);
+    ++count;
+    auto p = values.insert(value);
+    HPX_TEST(p.second);
+  });
+
+  HPX_TEST_EQ(count, static_cast<std::size_t>(zip.size()));
+  count = 0;
+
+  for (auto val : zip.these()) {
+    ++count;
+    HPX_TEST(values.contains(val));
+  }
+
+  HPX_TEST_EQ(count, values.size());
+}
+
+int main() {
+
+  testCoforallLoopZip(chplx::Range(0, 10));
+  testCoforallLoopZip(chplx::Range(0, 10), chplx::Range(0, 10));
+  testCoforallLoopZip(chplx::Range(0, 10), chplx::Range(0, 10),
+                      chplx::Range(0, 10));
+
+  testCoforallLoopZip(chplx::BoundedRange<int, true>(0, 10, 2),
+                      chplx::Range(0, 10));
+  testCoforallLoopZip(chplx::Range(0, 10, chplx::BoundsCategoryType::Open),
+                      chplx::Range(0, 10));
+  testCoforallLoopZip(
+      chplx::BoundedRange<int, true>(0, 10, 2, chplx::BoundsCategoryType::Open),
+      chplx::Range(0, 10));
+
+  testCoforallLoopZip(chplx::BoundedRange<int, true>(1, 9, 2),
+                      chplx::Range(0, 10));
+  testCoforallLoopZip(
+      chplx::BoundedRange<int, true>(1, 9, 2, chplx::BoundsCategoryType::Open),
+      chplx::Range(0, 10));
+
+  testCoforallLoopZip(chplx::Range(1, 0), chplx::Range(0, 10));
+
+  testCoforallLoopZip(by(chplx::BoundedRange<int, true>(1, 10), -1),
+                      chplx::Range(0, 10));
+  testCoforallLoopZip(by(chplx::BoundedRange<int, true>(1, 10), -2),
+                      chplx::Range(0, 10));
+
+  return hpx::util::report_errors();
+}

--- a/library/test/support/test_domain.cpp
+++ b/library/test/support/test_domain.cpp
@@ -19,15 +19,15 @@ void testDomain(chplx::Domain<1, T, Stridable> const &d) {
 
   HPX_TEST_EQ(d.stridable(), Stridable);
   HPX_TEST_EQ(d.size(), d.dim(0).size());
-  HPX_TEST_EQ(d.shape(), d.dim(0).size());
-  HPX_TEST_EQ(d.lowBound(), d.dim(0).lowBound());
-  HPX_TEST_EQ(d.low(), d.dim(0).low());
-  HPX_TEST_EQ(d.first(), d.dim(0).first());
-  HPX_TEST_EQ(d.highBound(), d.dim(0).highBound());
-  HPX_TEST_EQ(d.high(), d.dim(0).high());
-  HPX_TEST_EQ(d.last(), d.dim(0).last());
-  HPX_TEST_EQ(d.stride(), d.dim(0).stride());
-  HPX_TEST_EQ(d.alignment(), d.dim(0).alignment());
+  HPX_TEST_EQ(d.shape(), chplx::Tuple(d.dim(0).size()));
+  HPX_TEST_EQ(d.lowBound(), chplx::Tuple(d.dim(0).lowBound()));
+  HPX_TEST_EQ(d.low(), chplx::Tuple(d.dim(0).low()));
+  HPX_TEST_EQ(d.first(), chplx::Tuple(d.dim(0).first()));
+  HPX_TEST_EQ(d.highBound(), chplx::Tuple(d.dim(0).highBound()));
+  HPX_TEST_EQ(d.high(), chplx::Tuple(d.dim(0).high()));
+  HPX_TEST_EQ(d.last(), chplx::Tuple(d.dim(0).last()));
+  HPX_TEST_EQ(d.stride(), chplx::Tuple(d.dim(0).stride()));
+  HPX_TEST_EQ(d.alignment(), chplx::Tuple(d.dim(0).alignment()));
   HPX_TEST(d.isRectangular());
   HPX_TEST(!d.isIrregular());
   HPX_TEST(!d.isAssociative());

--- a/library/test/support/test_for_loop_domain.cpp
+++ b/library/test/support/test_for_loop_domain.cpp
@@ -9,6 +9,7 @@
 #include <hpx/hpx_main.hpp>
 #include <hpx/modules/testing.hpp>
 
+#include <cstddef>
 #include <set>
 
 template <int N, typename T, bool Stridable>
@@ -16,7 +17,7 @@ void testForLoopDomain(chplx::Domain<N, T, Stridable> d) {
 
   std::set<typename chplx::Domain<N, T, Stridable>::indexType> values;
 
-  int count = 0;
+  std::size_t count = 0;
 
   chplx::forLoop(d, [&](auto value) {
     ++count;
@@ -24,7 +25,7 @@ void testForLoopDomain(chplx::Domain<N, T, Stridable> d) {
     HPX_TEST(p.second);
   });
 
-  HPX_TEST_EQ(count, d.size());
+  HPX_TEST_EQ(count, static_cast<std::size_t>(d.size()));
 
   count = 0;
   for (auto const &e : d.these()) {
@@ -33,7 +34,7 @@ void testForLoopDomain(chplx::Domain<N, T, Stridable> d) {
     HPX_TEST(values.contains(e));
   }
 
-  HPX_TEST_EQ(static_cast<std::size_t>(count), values.size());
+  HPX_TEST_EQ(count, values.size());
 }
 
 namespace detail {

--- a/library/test/support/test_for_loop_zip.cpp
+++ b/library/test/support/test_for_loop_zip.cpp
@@ -1,0 +1,65 @@
+//  Copyright (c) 2023 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <chplx.hpp>
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <cstddef>
+#include <set>
+
+template <typename ...Rs>
+void testForLoopZip(Rs&&... rs) {
+
+  auto zip = chplx::zip(std::forward<Rs>(rs)...);
+
+  std::set<typename decltype(zip)::indexType> values;
+
+  std::size_t count = 0;
+
+  chplx::forLoop(zip, [&](auto value) {
+    ++count;
+    auto p = values.insert(value);
+    HPX_TEST(p.second);
+  });
+
+  HPX_TEST_EQ(count, static_cast<std::size_t>(zip.size()));
+
+  count = 0;
+  for (auto const &e : zip.these()) {
+
+    ++count;
+    HPX_TEST(values.contains(e));
+  }
+
+  HPX_TEST_EQ(static_cast<std::size_t>(count), values.size());
+}
+
+int main() {
+
+  testForLoopZip(chplx::Range(0, 10));
+  testForLoopZip(chplx::Range(0, 10), chplx::Range(0, 10));
+  testForLoopZip(chplx::Range(0, 10), chplx::Range(0, 10), chplx::Range(0, 10));
+
+  testForLoopZip(chplx::BoundedRange<int, true>(0, 10, 2), chplx::Range(0, 10));
+  testForLoopZip(chplx::Range(0, 10, chplx::BoundsCategoryType::Open), chplx::Range(0, 10));
+  testForLoopZip(chplx::BoundedRange<int, true>(
+      0, 10, 2, chplx::BoundsCategoryType::Open), chplx::Range(0, 10));
+
+  testForLoopZip(chplx::Range(1, 0), chplx::Range(0, 10));
+
+  testForLoopZip(chplx::BoundedRange<int, true>(1, 9, 2), chplx::Range(0, 10));
+  testForLoopZip(
+      chplx::BoundedRange<int, true>(1, 9, 2, chplx::BoundsCategoryType::Open), chplx::Range(0, 10));
+
+  testForLoopZip(by(chplx::BoundedRange<int, true>(1, 10), -1),
+                 chplx::Range(0, 10));
+  testForLoopZip(by(chplx::BoundedRange<int, true>(1, 10), -2),
+                 chplx::Range(0, 10));
+
+  return hpx::util::report_errors();
+}

--- a/library/test/support/test_forall_loop_domain.cpp
+++ b/library/test/support/test_forall_loop_domain.cpp
@@ -10,6 +10,8 @@
 #include <hpx/modules/testing.hpp>
 #include <hpx/thread.hpp>
 
+#include <cstddef>
+#include <mutex>
 #include <set>
 
 template <int N, typename T, bool Stridable>
@@ -19,7 +21,7 @@ void testForallLoopDomain(chplx::Domain<N, T, Stridable> d) {
   std::set<indexType> values;
   hpx::mutex mtx;
 
-  T count = 0;
+  std::size_t count = 0;
 
   chplx::forallLoop(d, [&](auto value) {
     std::lock_guard l(mtx);
@@ -28,7 +30,7 @@ void testForallLoopDomain(chplx::Domain<N, T, Stridable> d) {
     HPX_TEST(p.second);
   });
 
-  HPX_TEST_EQ(count, d.size());
+  HPX_TEST_EQ(count, static_cast<std::size_t>(d.size()));
   count = 0;
 
   for (auto const &e : d.these()) {
@@ -37,7 +39,7 @@ void testForallLoopDomain(chplx::Domain<N, T, Stridable> d) {
     HPX_TEST(values.contains(e));
   }
 
-  HPX_TEST_EQ(static_cast<std::size_t>(count), values.size());
+  HPX_TEST_EQ(count, values.size());
 }
 
 namespace detail {
@@ -45,7 +47,7 @@ namespace detail {
 //-----------------------------------------------------------------------------
 template <typename... Rs, std::size_t... Is>
 void testForallLoopDomains1D(chplx::Tuple<Rs...> const &r,
-                          std::index_sequence<Is...> s) {
+                             std::index_sequence<Is...> s) {
 
   (testForallLoopDomain(chplx::Domain(std::get<Is>(r))), ...);
 }
@@ -53,14 +55,14 @@ void testForallLoopDomains1D(chplx::Tuple<Rs...> const &r,
 //-----------------------------------------------------------------------------
 template <std::size_t N, typename... Rs, std::size_t... Js>
 void testForallLoopDomains2D(chplx::Tuple<Rs...> const &r,
-                          std::index_sequence<Js...>) {
+                             std::index_sequence<Js...>) {
 
   (testForallLoopDomain(chplx::Domain(std::get<Js>(r), std::get<N>(r))), ...);
 }
 
 template <typename... Rs, std::size_t... Is>
 void testForallLoopDomains2D(chplx::Tuple<Rs...> const &r,
-                          std::index_sequence<Is...> s) {
+                             std::index_sequence<Is...> s) {
 
   (testForallLoopDomains2D<Is>(r, s), ...);
 }
@@ -68,7 +70,7 @@ void testForallLoopDomains2D(chplx::Tuple<Rs...> const &r,
 //-----------------------------------------------------------------------------
 template <std::size_t N, std::size_t M, typename... Rs, std::size_t... Js>
 void testForallLoopDomains3D_2(chplx::Tuple<Rs...> const &r,
-                            std::index_sequence<Js...>) {
+                               std::index_sequence<Js...>) {
 
   (testForallLoopDomain(
        chplx::Domain(std::get<Js>(r), std::get<N>(r), std::get<M>(r))),
@@ -77,14 +79,14 @@ void testForallLoopDomains3D_2(chplx::Tuple<Rs...> const &r,
 
 template <std::size_t N, typename... Rs, std::size_t... Is>
 void testForallLoopDomains3D_1(chplx::Tuple<Rs...> const &r,
-                            std::index_sequence<Is...> s) {
+                               std::index_sequence<Is...> s) {
 
   (testForallLoopDomains3D_2<N, Is>(r, s), ...);
 }
 
 template <typename... Rs, std::size_t... Is>
 void testForallLoopDomains3D(chplx::Tuple<Rs...> const &r,
-                          std::index_sequence<Is...> s) {
+                             std::index_sequence<Is...> s) {
 
   (testForallLoopDomains3D_1<Is>(r, s), ...);
 }
@@ -93,30 +95,30 @@ void testForallLoopDomains3D(chplx::Tuple<Rs...> const &r,
 template <std::size_t N, std::size_t M, std::size_t O, typename... Rs,
           std::size_t... Js>
 void testForallLoopDomains4D_3(chplx::Tuple<Rs...> const &r,
-                            std::index_sequence<Js...>) {
+                               std::index_sequence<Js...>) {
 
   (testForallLoopDomain(chplx::Domain(std::get<Js>(r), std::get<N>(r),
-                                   std::get<M>(r), std::get<O>(r))),
+                                      std::get<M>(r), std::get<O>(r))),
    ...);
 }
 
 template <std::size_t N, std::size_t M, typename... Rs, std::size_t... Is>
 void testForallLoopDomains4D_2(chplx::Tuple<Rs...> const &r,
-                            std::index_sequence<Is...> s) {
+                               std::index_sequence<Is...> s) {
 
   (testForallLoopDomains4D_3<N, M, Is>(r, s), ...);
 }
 
 template <std::size_t N, typename... Rs, std::size_t... Is>
 void testForallLoopDomains4D_1(chplx::Tuple<Rs...> const &r,
-                            std::index_sequence<Is...> s) {
+                               std::index_sequence<Is...> s) {
 
   (testForallLoopDomains4D_2<N, Is>(r, s), ...);
 }
 
 template <typename... Rs, std::size_t... Is>
 void testForallLoopDomains4D(chplx::Tuple<Rs...> const &r,
-                          std::index_sequence<Is...> s) {
+                             std::index_sequence<Is...> s) {
 
   (testForallLoopDomains4D_1<Is>(r, s), ...);
 }

--- a/library/test/support/test_forall_loop_range.cpp
+++ b/library/test/support/test_forall_loop_range.cpp
@@ -10,13 +10,14 @@
 #include <hpx/modules/testing.hpp>
 #include <hpx/thread.hpp>
 
+#include <cstddef>
 #include <mutex>
 #include <set>
 
 template <typename T, chplx::BoundedRangeType BoundedType, bool Stridable>
 void testForallLoopRange(chplx::Range<T, BoundedType, Stridable> r) {
 
-  T count = 0;
+  std::size_t count = 0;
 
   std::set<T> values;
   hpx::mutex mtx;
@@ -28,7 +29,7 @@ void testForallLoopRange(chplx::Range<T, BoundedType, Stridable> r) {
     HPX_TEST(p.second);
   });
 
-  HPX_TEST_EQ(count, r.size());
+  HPX_TEST_EQ(count, static_cast<std::size_t>(r.size()));
   count = 0;
 
   for (auto val : r.these()) {
@@ -36,7 +37,7 @@ void testForallLoopRange(chplx::Range<T, BoundedType, Stridable> r) {
     HPX_TEST(values.contains(val));
   }
 
-  HPX_TEST_EQ(count, r.size());
+  HPX_TEST_EQ(count, values.size());
 }
 
 int main() {

--- a/library/test/support/test_forall_loop_zip.cpp
+++ b/library/test/support/test_forall_loop_zip.cpp
@@ -1,0 +1,72 @@
+//  Copyright (c) 2023 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <chplx.hpp>
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/modules/testing.hpp>
+#include <hpx/thread.hpp>
+
+#include <cstddef>
+#include <mutex>
+#include <set>
+
+template <typename... Rs> void testForallLoopZip(Rs &&...rs) {
+
+  std::size_t count = 0;
+  auto zip = chplx::zip(std::forward<Rs>(rs)...);
+
+  std::set<typename decltype(zip)::indexType> values;
+  hpx::mutex mtx;
+
+  chplx::forallLoop(zip, [&](auto value) {
+    std::lock_guard l(mtx);
+    ++count;
+    auto p = values.insert(value);
+    HPX_TEST(p.second);
+  });
+
+  HPX_TEST_EQ(count, static_cast<std::size_t>(zip.size()));
+  count = 0;
+
+  for (auto val : zip.these()) {
+    ++count;
+    HPX_TEST(values.contains(val));
+  }
+
+  HPX_TEST_EQ(count, values.size());
+}
+
+int main() {
+
+  testForallLoopZip(chplx::Range(0, 10));
+  testForallLoopZip(chplx::Range(0, 10), chplx::Range(0, 10));
+  testForallLoopZip(chplx::Range(0, 10), chplx::Range(0, 10),
+                    chplx::Range(0, 10));
+
+  testForallLoopZip(chplx::BoundedRange<int, true>(0, 10, 2),
+                    chplx::Range(0, 10));
+  testForallLoopZip(chplx::Range(0, 10, chplx::BoundsCategoryType::Open),
+                    chplx::Range(0, 10));
+  testForallLoopZip(
+      chplx::BoundedRange<int, true>(0, 10, 2, chplx::BoundsCategoryType::Open),
+      chplx::Range(0, 10));
+
+  testForallLoopZip(chplx::Range(1, 0), chplx::Range(0, 10));
+
+  testForallLoopZip(chplx::BoundedRange<int, true>(1, 9, 2),
+                    chplx::Range(0, 10));
+  testForallLoopZip(
+      chplx::BoundedRange<int, true>(1, 9, 2, chplx::BoundsCategoryType::Open),
+      chplx::Range(0, 10));
+
+  testForallLoopZip(by(chplx::BoundedRange<int, true>(1, 10), -1),
+                    chplx::Range(0, 10));
+  testForallLoopZip(by(chplx::BoundedRange<int, true>(1, 10), -2),
+                    chplx::Range(0, 10));
+
+  return hpx::util::report_errors();
+}

--- a/library/test/support/test_zip.cpp
+++ b/library/test/support/test_zip.cpp
@@ -1,0 +1,133 @@
+//  Copyright (c) 2023 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <chplx.hpp>
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace detail {
+
+template <typename R>
+decltype(auto) collectResult(R &&r, std::size_t max_values) {
+
+  std::vector<typename std::decay_t<R>::indexType> result;
+  result.reserve(max_values);
+  for (auto elem : r.these()) {
+    result.push_back(elem);
+    if (--max_values == 0) {
+      break;
+    }
+  }
+  return result;
+}
+
+template <typename... Rs>
+decltype(auto) collectResults(std::size_t max_values, Rs &&...rs) {
+
+  return chplx::Tuple(collectResult(rs, max_values)...);
+}
+
+template <typename... Ts1, typename... Ts2>
+bool compare(chplx::Tuple<Ts1...> const &t,
+             chplx::Tuple<std::vector<Ts2>...> const &expected, std::size_t i) {
+
+  return t == chplx::detail::lift(expected, [i](auto &&v) { return v[i]; });
+}
+
+template <typename... Ts>
+bool compareSizes(std::size_t size,
+                  chplx::Tuple<std::vector<Ts>...> const &expected) {
+
+  auto result = chplx::detail::lift(
+      expected, [size](auto &&v) { return v.size() == size; });
+
+  return chplx::reduce(
+      result, [](bool init, bool val) { return init && val; }, true);
+}
+
+template <typename... Rs> auto collectSizes(Rs const &...rs) {
+
+  return chplx::detail::lift(chplx::Tuple(rs...), [](auto &&r) {
+    return r.isBounded() ? r.size() : chplx::detail::MaxValue_v<std::size_t>;
+  });
+}
+
+} // namespace detail
+
+template <typename... Rs> void testZip(Rs &&...rs) {
+
+  std::size_t max_values = chplx::reduce(
+      detail::collectSizes(rs...),
+      [](std::size_t init, std::size_t val) { return (std::min)(init, val); },
+      chplx::detail::MaxValue_v<std::size_t>);
+
+  auto expected = detail::collectResults(max_values, rs...);
+
+  std::size_t count = 0;
+
+  for (auto &&element : chplx::zip(std::forward<Rs>(rs)...).these()) {
+    HPX_TEST(detail::compare(element, expected, count));
+    ++count;
+  }
+
+  HPX_TEST(detail::compareSizes(count, expected));
+}
+
+int main() {
+
+  // zippered iteration with bounded ranges
+  {
+    auto constexpr r1 = chplx::Range(0, 10);
+
+    testZip(r1);
+    testZip(r1, r1);
+    testZip(r1, r1, r1);
+    testZip(r1, r1, r1, r1);
+
+    auto constexpr r2 = chplx::BoundedRange<int, true>(0, 10, -1);
+    testZip(r1, r2);
+    testZip(r2, r1);
+
+    auto constexpr r3 = chplx::BoundedRange<int, true>(0, 10, 2);
+
+    testZip(r3);
+    testZip(r3, r3);
+    testZip(r3, r3, r3);
+    testZip(r3, r3, r3, r3);
+
+    auto constexpr r4 = chplx::BoundedRange<int, true>(0, 10, -2);
+    testZip(r3, r4);
+    testZip(r4, r3);
+  }
+
+  // iteration with bounded ranges of different length
+  {
+    auto constexpr r1 = chplx::Range(1, 9);
+    auto constexpr r2 = chplx::Range(2, 5);
+    testZip(r1, r2);
+    testZip(r2, r1);
+  }
+
+  // iteration with unbounded ranges
+  {
+    auto constexpr r1 = chplx::Range(1, 9);
+    auto constexpr r2 = chplx::Range(1);
+    auto constexpr r3 = chplx::Range(chplx::RangeInit::noValue, 9, -1);
+    testZip(r1, r2);
+    testZip(r1, r3);
+    testZip(r2, r1);
+    testZip(r3, r1);
+  }
+
+  return hpx::util::report_errors();
+}


### PR DESCRIPTION
`chplx::zip()` supports zippered iteration over ranges, tuples, and domains

Note, this requires for https://github.com/STEllAR-GROUP/hpx/pull/6187 to be merged.