### PR TITLE
Enable passing arbitrary number of arguments to new tasks (begin and coforall)

### DIFF
--- a/library/include/chplx/adapt_tuple.hpp
+++ b/library/include/chplx/adapt_tuple.hpp
@@ -21,23 +21,25 @@
 #include <memory>
 #include <tuple>
 #include <type_traits>
+#include <utility>
 #include <variant>
 
 namespace chplx {
 namespace detail {
 
 //-----------------------------------------------------------------------------
-template <typename Tuple, typename F, typename Pack> struct forLoopTable;
+template <typename Tuple, typename F, typename Pack, typename... Args>
+struct forLoopTable;
 
-template <typename Tuple, typename F, std::size_t... Is>
-struct forLoopTable<Tuple, F, std::index_sequence<Is...>> {
+template <typename Tuple, typename F, std::size_t... Is, typename... Args>
+struct forLoopTable<Tuple, F, std::index_sequence<Is...>, Args...> {
 
   template <std::size_t N>
-  static constexpr void accessFunc(Tuple &t, F &f) noexcept {
-    f(std::get<N>(t));
+  static constexpr void accessFunc(Tuple &t, F &f, Args &...args) noexcept {
+    f(std::get<N>(t), args...);
   }
 
-  using accessFuncType = void (*)(Tuple &t, F &f) noexcept;
+  using accessFuncType = void (*)(Tuple &t, F &f, Args &...args) noexcept;
 
   static constexpr std::array<accessFuncType, sizeof...(Is)> lookupTable = {
       &accessFunc<Is>...};

--- a/library/include/chplx/begin.hpp
+++ b/library/include/chplx/begin.hpp
@@ -11,9 +11,10 @@
 
 namespace chplx {
 
-template <typename F> void begin(F &&f) {
+template <typename F, typename... Args> void begin(F &&f, Args &&...args) {
 
   hpx::parallel::execution::post(hpx::execution::par.executor(),
-                                 std::forward<F>(f));
+                                 std::forward<F>(f),
+                                 std::forward<Args>(args)...);
 }
 } // namespace chplx

--- a/library/test/support/test_coforall_loop_assoc_domain.cpp
+++ b/library/test/support/test_coforall_loop_assoc_domain.cpp
@@ -21,7 +21,7 @@ template <typename T> void testCoforallLoopDomain(chplx::AssocDomain<T> const &d
 
   std::size_t count = 0;
 
-  chplx::coforallLoop(d, [&](auto value) {
+  chplx::coforall(d, [&](auto value) {
     std::lock_guard l(mtx);
     ++count;
     auto p = values.insert(value);

--- a/library/test/support/test_coforall_loop_domain.cpp
+++ b/library/test/support/test_coforall_loop_domain.cpp
@@ -23,7 +23,7 @@ void testCoforallLoopDomain(chplx::Domain<N, T, Stridable> d) {
 
   std::size_t count = 0;
 
-  chplx::coforallLoop(d, [&](auto value) {
+  chplx::coforall(d, [&](auto value) {
     std::lock_guard l(mtx);
     ++count;
     auto p = values.insert(value);

--- a/library/test/support/test_coforall_loop_range.cpp
+++ b/library/test/support/test_coforall_loop_range.cpp
@@ -22,7 +22,7 @@ void testCoforallLoopRange(chplx::Range<T, BoundedType, Stridable> r) {
   std::set<T> values;
   hpx::mutex mtx;
 
-  chplx::coforallLoop(r, [&](auto value) {
+  chplx::coforall(r, [&](auto value) {
     std::lock_guard l(mtx);
     ++count;
     auto p = values.insert(value);

--- a/library/test/support/test_coforall_loop_tuple.cpp
+++ b/library/test/support/test_coforall_loop_tuple.cpp
@@ -23,7 +23,7 @@ template <typename T> void testCoforallLoopHomogenousTuple(T val) {
     chplx::Tuple<> t;
 
     called = 0;
-    chplx::coforallLoop(t, [&](auto value) {
+    chplx::coforall(t, [&](auto value) {
       ++called;
       HPX_TEST_EQ(value, val);
     });
@@ -35,7 +35,7 @@ template <typename T> void testCoforallLoopHomogenousTuple(T val) {
     chplx::Tuple<T> t{val};
 
     called = 0;
-    chplx::coforallLoop(t, [&](auto value) {
+    chplx::coforall(t, [&](auto value) {
       ++called;
       HPX_TEST_EQ(value, val);
     });
@@ -47,7 +47,7 @@ template <typename T> void testCoforallLoopHomogenousTuple(T val) {
     chplx::Tuple<T, T> t{val, val};
 
     called = 0;
-    chplx::coforallLoop(t, [&](auto value) {
+    chplx::coforall(t, [&](auto value) {
       ++called;
       HPX_TEST_EQ(value, val);
     });
@@ -60,7 +60,7 @@ template <typename T> void testCoforallLoopHomogenousTuple(T val) {
                                                  val, val, val, val, val};
 
     called = 0;
-    chplx::coforallLoop(t, [&](auto value) {
+    chplx::coforall(t, [&](auto value) {
       ++called;
       HPX_TEST_EQ(value, val);
     });
@@ -95,7 +95,7 @@ template <typename... Ts> void testCoforallLoopTuple(Ts... ts) {
   hpx::mutex mtx;
 
   called = 0;
-  chplx::coforallLoop(t, [&](auto value) {
+  chplx::coforall(t, [&](auto value) {
     std::lock_guard l(mtx);
     ++called;
     auto p = values.insert(value);

--- a/library/test/support/test_coforall_loop_zip.cpp
+++ b/library/test/support/test_coforall_loop_zip.cpp
@@ -23,7 +23,7 @@ template <typename... Rs> void testCoforallLoopZip(Rs &&...rs) {
 
   hpx::mutex mtx;
 
-  chplx::coforallLoop(zip, [&](auto value) {
+  chplx::coforall(zip, [&](auto value) {
     std::lock_guard l(mtx);
     ++count;
     auto p = values.insert(value);

--- a/library/test/support/test_for_loop_tuple.cpp
+++ b/library/test/support/test_for_loop_tuple.cpp
@@ -93,7 +93,7 @@ template <typename... Ts> void testForLoopTuple(Ts... ts) {
   hpx::mutex mtx;
 
   called = 0;
-  chplx::coforallLoop(t, [&](auto value) {
+  chplx::coforall(t, [&](auto value) {
     std::lock_guard l(mtx);
     ++called;
     auto p = values.insert(value);

--- a/library/test/support/test_forall_loop_tuple.cpp
+++ b/library/test/support/test_forall_loop_tuple.cpp
@@ -93,7 +93,7 @@ template <typename... Ts> void testForallLoopTuple(Ts... ts) {
   hpx::mutex mtx;
 
   called = 0;
-  chplx::coforallLoop(t, [&](auto value) {
+  chplx::coforall(t, [&](auto value) {
     std::lock_guard l(mtx);
     ++called;
     auto p = values.insert(value);


### PR DESCRIPTION
- flyby: rename coforallLoop() to coforall()