### PR TITLE
Allowing to pass arbitrary number of arguments to body of forall

### DIFF
--- a/library/include/chplx/forall_loop.hpp
+++ b/library/include/chplx/forall_loop.hpp
@@ -23,61 +23,93 @@ namespace chplx {
 
 //-----------------------------------------------------------------------------
 // forall loop for tuples
-template <typename... Ts, typename F> void forall(Tuple<Ts...> const &t, F &&f) {
+template <typename... Ts, typename F, typename... Args>
+void forall(Tuple<Ts...> const &t, F &&f, Args &&...args) {
 
   if constexpr (sizeof...(Ts) != 0) {
 
     if constexpr (Tuple<Ts...>::isHomogenous()) {
 
-      hpx::ranges::for_each(hpx::execution::par, HomogenousTupleRange(t.base()),
-                            std::forward<F>(f));
+      hpx::ranges::for_each(
+          hpx::execution::par, HomogenousTupleRange(t.base()),
+          [&, ... fargs = detail::task_intent<std::decay_t<Args>>::call(
+                  std::forward<Args>(args))]<typename Arg>(Arg &&value) {
+            f(std::forward<Arg>(value),
+              hpx::util::decay_unwrap<decltype(fargs)>::call(fargs)...);
+          });
     } else {
 
       using table =
-          detail::forLoopTable<Tuple<Ts...>, F,
-                               std::make_index_sequence<sizeof...(Ts)>>;
+          detail::forLoopTable<Tuple<Ts...> const, F,
+                               std::make_index_sequence<sizeof...(Ts)>,
+                               Args...>;
 
       hpx::experimental::for_loop(
           hpx::execution::par, 0, t.size(),
-          [&](std::size_t i) { table::lookupTable[i](t, f); });
+          [&, ... fargs = detail::task_intent<std::decay_t<Args>>::call(
+                  std::forward<Args>(args))](std::size_t i) mutable {
+            table::lookupTable[i](
+                t, f, hpx::util::decay_unwrap<decltype(fargs)>::call(fargs)...);
+          });
     }
   }
 }
 
 //-----------------------------------------------------------------------------
 // forall loop for ranges
-template <typename T, BoundedRangeType BoundedType, bool Stridable, typename F>
-void forall(Range<T, BoundedType, Stridable> const &r, F &&f) {
+template <typename T, BoundedRangeType BoundedType, bool Stridable, typename F,
+          typename... Args>
+void forall(Range<T, BoundedType, Stridable> const &r, F &&f, Args &&...args) {
 
   hpx::ranges::experimental::for_loop(
-      hpx::execution::par, detail::IteratorGenerator(r), std::forward<F>(f));
+      hpx::execution::par, detail::IteratorGenerator(r),
+      [&, ... fargs = detail::task_intent<std::decay_t<Args>>::call(
+              std::forward<Args>(args))]<typename Arg>(Arg &&value) {
+        f(std::forward<Arg>(value),
+          hpx::util::decay_unwrap<decltype(fargs)>::call(fargs)...);
+      });
 }
 
 //-----------------------------------------------------------------------------
 // forall loop for domain
-template <int N, typename T, bool Stridable, typename F>
-void forall(Domain<N, T, Stridable> const &d, F &&f) {
+template <int N, typename T, bool Stridable, typename F, typename... Args>
+void forall(Domain<N, T, Stridable> const &d, F &&f, Args &&...args) {
 
   hpx::ranges::experimental::for_loop(
-      hpx::execution::par, detail::IteratorGenerator(d), std::forward<F>(f));
+      hpx::execution::par, detail::IteratorGenerator(d),
+      [&, ... fargs = detail::task_intent<std::decay_t<Args>>::call(
+              std::forward<Args>(args))]<typename Arg>(Arg &&value) {
+        f(std::forward<Arg>(value),
+          hpx::util::decay_unwrap<decltype(fargs)>::call(fargs)...);
+      });
 }
 
 //-----------------------------------------------------------------------------
 // forall loop for associative domains
-template <typename T, typename F> void forall(AssocDomain<T> const &d, F &&f) {
+template <typename T, typename F, typename... Args>
+void forall(AssocDomain<T> const &d, F &&f, Args &&...args) {
 
-  hpx::ranges::experimental::for_loop(hpx::execution::par,
-                                      detail::IteratorGenerator(d, 0, d.size()),
-                                      std::forward<F>(f));
+  hpx::ranges::experimental::for_loop(
+      hpx::execution::par, detail::IteratorGenerator(d, 0, d.size()),
+      [&, ... fargs = detail::task_intent<std::decay_t<Args>>::call(
+              std::forward<Args>(args))]<typename Arg>(Arg &&value) {
+        f(std::forward<Arg>(value),
+          hpx::util::decay_unwrap<decltype(fargs)>::call(fargs)...);
+      });
 }
 
 //-----------------------------------------------------------------------------
 // forall loop for zippered iteration
-template <typename... Rs, typename F>
-void forall(detail::ZipRange<Rs...> const &zr, F &&f) {
+template <typename... Rs, typename F, typename... Args>
+void forall(detail::ZipRange<Rs...> const &zr, F &&f, Args &&...args) {
 
   hpx::ranges::experimental::for_loop(
-      hpx::execution::par, detail::IteratorGenerator(zr), std::forward<F>(f));
+      hpx::execution::par, detail::IteratorGenerator(zr),
+      [&, ... fargs = detail::task_intent<std::decay_t<Args>>::call(
+              std::forward<Args>(args))]<typename Arg>(Arg &&value) {
+        f(std::forward<Arg>(value),
+          hpx::util::decay_unwrap<decltype(fargs)>::call(fargs)...);
+      });
 }
 
 } // namespace chplx

--- a/library/test/support/test_coforall_loop_range.cpp
+++ b/library/test/support/test_coforall_loop_range.cpp
@@ -68,9 +68,9 @@ void testCoforallLoopRange(chplx::Range<T, BoundedType, Stridable> r) {
 }
 
 template <typename T, chplx::BoundedRangeType BoundedType, bool Stridable,
-          typename Args>
+          typename Arg>
 void testCoforallLoopRange(chplx::Range<T, BoundedType, Stridable> r,
-                           Args &&arg) {
+                           Arg &&arg) {
 
   std::size_t count = 0;
 


### PR DESCRIPTION
- making sure Sync<> and Single<> are being passed as references