### PR TITLE
Adding backend command line options for controlling #line directive

### DIFF
--- a/backend/CMakeLists.txt
+++ b/backend/CMakeLists.txt
@@ -42,12 +42,14 @@ llvm_map_components_to_libnames(llvm_libs support core irreader)
 set(chplx_sources
     src/symboltypes.cpp src/symbolbuildingvisitor.cpp src/programtree.cpp
     src/programtreebuildingvisitor.cpp src/codegenvisitor.cpp src/cmakegen.cpp src/driver.cpp
+    src/util.cpp
 )
 
 set(chplx_headers
     include/hpx/symboltypes.hpp include/hpx/symbolbuildingvisitor.hpp
     include/hpx/programtree.hpp include/hpx/programtreebuildingvisitor.hpp
-    include/hpx/codegenvisitor.hpp include/hpx/cmakegen.hpp include/ErrorGuard.h
+    include/hpx/codegenvisitor.hpp include/hpx/cmakegen.hpp include/hpx/util.hpp
+    include/ErrorGuard.h
 )
 
 if(MSVC)

--- a/backend/cmake/CHPLX_Compile.cmake
+++ b/backend/cmake/CHPLX_Compile.cmake
@@ -60,7 +60,7 @@ function(chplx_compile name)
   file(MAKE_DIRECTORY ${output_dir})
   add_custom_command(
     OUTPUT ${output_dir}/${name}.cpp ${output_dir}/${name}.hpp
-    COMMAND "$<TARGET_FILE:chplx>" "-f" "${input_path}"
+    COMMAND "$<TARGET_FILE:chplx>" "-f" "${input_path}" "-F"
     DEPENDS "${${name}_SOURCE}" ${${name}_DEPENDENCIES}
     WORKING_DIRECTORY "${output_dir}"
     COMMENT "Compiling Chapel file ${${name}_SOURCE}."

--- a/backend/include/hpx/util.hpp
+++ b/backend/include/hpx/util.hpp
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2023 Christopher Taylor
+ *
+ * SPDX-License-Identifier: BSL-1.0
+ * Distributed under the Boost Software License, Version 1.0. *(See accompanying
+ * file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+ */
+
+#pragma once
+
+#include <string>
+
+namespace chplx::util {
+
+// global options
+extern bool suppressLineDirectives;
+extern bool fullFilePath;
+
+// emit line directive
+std::string emitLineDirective(char const* name, int line);
+} // namespace chplx::util

--- a/backend/src/driver.cpp
+++ b/backend/src/driver.cpp
@@ -19,6 +19,8 @@
 #include "hpx/symbolbuildingvisitor.hpp"
 #include "hpx/codegenvisitor.hpp"
 #include "hpx/cmakegen.hpp"
+#include "hpx/util.hpp"
+
 #include "ErrorGuard.h"
 
 #include <optional>
@@ -31,6 +33,7 @@
 #include <iostream>
 
 #include <getopt.h> /* getopt API */
+#include <fmt/core.h>
 
 using namespace chpl;
 using namespace uast;
@@ -72,6 +75,18 @@ static void generateHpxMainEnd(std::ostream & fos) {
        << "}" << std::endl;
 }
 
+// generate help string
+void usage() {
+   constexpr char const* helpstring =
+R"(chplx -help:
+  chplx [options] -f <full path to file name or file name>
+    options: -E: suppress generating #line directives (default: false)
+             -F: suppress generating full path for #line directives (default: true)
+)";
+
+   std::cout << helpstring << std::flush;
+}
+
 int main(int argc, char ** argv) {
 
    Context context;
@@ -85,15 +100,23 @@ int main(int argc, char ** argv) {
    int opt = 0;
 
    // Retrieve the options:
-   while ( (opt = getopt(argc, argv, "f:h")) != -1 ) {  // for each option...
+   while ( (opt = getopt(argc, argv, "f:hEF")) != -1 ) {  // for each option...
       switch ( opt ) {
          case 'f':
             filePath = std::string{optarg};
          break;
-         case 'h':
-            std::cout << "chplx -help: `chplx -f <full path to file name or file name>`" << std::endl << std::flush;
-            return 1;
+         case 'E':
+            chplx::util::suppressLineDirectives = true;
          break;
+         case 'F':
+            chplx::util::fullFilePath = false;
+         break;
+         default:
+            std::cout << "chplx: unknown command line option: -" << opt << std::endl << std::flush;
+            [[fallthrough]];
+         case 'h':
+            usage();
+            return 1;
       }
    }
 

--- a/backend/src/programtreebuildingvisitor.cpp
+++ b/backend/src/programtreebuildingvisitor.cpp
@@ -7,6 +7,7 @@
  */
 #include "hpx/programtree.hpp"
 #include "hpx/programtreebuildingvisitor.hpp"
+#include "hpx/util.hpp"
 #include "chpl/uast/all-uast.h"
 
 #include <variant>
@@ -20,6 +21,10 @@
 using namespace chplx::ast::hpx;
 using namespace chpl::uast;
 using namespace chpl::ast::visitors::hpx;
+
+// global options
+extern bool suppressLineDirectives;
+extern bool fullFilePath;
 
 namespace chplx { namespace ast { namespace visitors { namespace hpx {
 
@@ -44,11 +49,8 @@ struct VariableVisitor {
    uast::AstNode const* ast;
 
    std::string emitChapelLine(uast::AstNode const* ast) const {
-      auto fp = br.filePath();
-      std::stringstream os{};
-      std::filesystem::path p(fp.c_str());
-      os << "#line " << br.idToLocation(ast->id(), fp).line()  << " \"" << p.filename().string() << "\"";
-      return os.str();
+      auto const fp = br.filePath();
+      return chplx::util::emitLineDirective(fp.c_str(), br.idToLocation(ast->id(), fp).line());
    }
 
    template<typename T>
@@ -102,14 +104,11 @@ struct VariableLiteralVisitor {
    uast::AstNode const* ast;
 
    std::string emitChapelLine(uast::AstNode const* ast) const {
-      auto fp = br.filePath();
-      std::stringstream os{};
-      std::filesystem::path p(fp.c_str());
-      os << "#line " << br.idToLocation(ast->id(), fp).line()  << " \"" << p.filename().string() << "\"";
-      return os.str();
+      auto const fp = br.filePath();
+      return chplx::util::emitLineDirective(fp.c_str(), br.idToLocation(ast->id(), fp).line());
    }
 
-   template<typename T>
+  template<typename T>
    void operator()(T const& t) {
    }
 
@@ -151,11 +150,8 @@ struct VariableLiteralVisitor {
 };
 
 std::string ProgramTreeBuildingVisitor::emitChapelLine(uast::AstNode const* ast) {
-   auto fp = br.filePath();
-   std::stringstream os{};
-   std::filesystem::path p(fp.c_str());
-   os << "#line " << br.idToLocation(ast->id(), fp).line()  << " \"" << p.filename().string() << "\"";
-   return os.str();
+   auto const fp = br.filePath();
+   return chplx::util::emitLineDirective(fp.c_str(), br.idToLocation(ast->id(), fp).line());
 }
 
 bool ProgramTreeBuildingVisitor::enter(const uast::AstNode * ast) {

--- a/backend/src/symbolbuildingvisitor.cpp
+++ b/backend/src/symbolbuildingvisitor.cpp
@@ -7,6 +7,7 @@
  * file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
  */
 #include "hpx/symbolbuildingvisitor.hpp"
+#include "hpx/util.hpp"
 #include "chpl/uast/all-uast.h"
 
 #include <variant>
@@ -16,7 +17,11 @@
 #include <numeric>
 
 using namespace chpl::uast;
- 
+
+// global options
+extern bool suppressLineDirectives;
+extern bool fullFilePath;
+
 namespace chpl { namespace ast { namespace visitors { namespace hpx {
 
 void SymbolBuildingVisitor::addSymbolEntry(char const* type, Symbol && symbol) {
@@ -79,11 +84,8 @@ SymbolBuildingVisitor::SymbolBuildingVisitor(chpl::uast::BuilderResult const& ch
 }
 
 std::string SymbolBuildingVisitor::emitChapelLine(uast::AstNode const* ast) {
-   auto fp = br.filePath();
-   std::stringstream os{};
-   std::filesystem::path p(fp.c_str());
-   os << "#line " << br.idToLocation(ast->id(), fp).line()  << " \"" << p.filename().string() << "\"";
-   return os.str();
+   auto const fp = br.filePath();
+   return chplx::util::emitLineDirective(fp.c_str(), br.idToLocation(ast->id(), fp).line());
 }
 
 bool SymbolBuildingVisitor::enter(const uast::AstNode * ast) {

--- a/backend/src/util.cpp
+++ b/backend/src/util.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2023 Christopher Taylor
+ *
+ * SPDX-License-Identifier: BSL-1.0
+ * Distributed under the Boost Software License, Version 1.0. *(See accompanying
+ * file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+ */
+
+#include <hpx/util.hpp>
+
+#include <filesystem>
+#include <string>
+
+#include <fmt/core.h>
+
+namespace chplx::util {
+
+// global options
+bool suppressLineDirectives = false;
+bool fullFilePath = true;
+
+// emit line directive
+std::string emitLineDirective(char const* name, int line) {
+  if (!suppressLineDirectives) {
+    std::filesystem::path p(name);
+    return fmt::format("#line {0} \"{1}\"\n", line,
+                       (fullFilePath ? p : p.filename()).string());
+  }
+  return {};
+}
+} // namespace chplx::util


### PR DESCRIPTION
Adding backend command line options for controlling:
- if #line directives are to be generated
- if file name in #line directives has full path or not
- flyby: consolidate similar code into separate function